### PR TITLE
Add dependabot and python test runner to CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values.
+    directory: "/" # Location of package manifests.
+    schedule:
+      interval: "daily"
+
+  # Maintain dependencies for GitHub Actions.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/fastapi_crud.yml
+++ b/.github/workflows/fastapi_crud.yml
@@ -1,0 +1,62 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    branches:
+      - master
+
+  schedule:
+    # Every day at 1.00 UTC.
+    - cron: "0 1 * * *"
+
+# If you trigger a new workflow while the previous one is running,
+# this will cancel the previous one.
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  run-tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Use matrix strategy to run the tests on multiple Py versions on multiple OSs.
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.8", "3.9", "3.10"]
+        include:
+        - os: ubuntu-latest
+          path: ~/.cache/pip
+        - os: macos-latest
+          path: ~/Library/Caches/pip
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ matrix.path }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}-${{ hashFiles('**/requirements-dev.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install the Dependencies
+        run: |
+          echo "Installing the dependencies..."
+          python -m pip install -r requirements.txt -r requirements-dev.txt
+
+      - name: Check Linter
+        run: |
+          echo "Checking linter formatting..."
+          make lint-check
+
+      - name: Run Tests
+        run: |
+          echo "Running the tests..."
+          python -m pytest -v -s

--- a/fastapi-crud/Makefile
+++ b/fastapi-crud/Makefile
@@ -19,7 +19,9 @@ lint-check:  ## Check whether the codebase satisfies the linter rules.
 	@echo "Checking linter rules..."
 	@echo "========================"
 	@echo
-	@make lint-check
+	@black --fast --check $(path)
+	@isort --check $(path)
+	@flake8 $(path)
 	@echo 'y' | mypy $(path) --install-types
 
 


### PR DESCRIPTION
This adds a Python-specific workflow file that runs the FastAPI tests in CI. The CI will also run every day at UTC 1. Dependabot will keep the dependencies fresh. 