### PR TITLE
Add NodeJS example using EdgeDB Auth

### DIFF
--- a/nodejs-auth/dbschema/default.esdl
+++ b/nodejs-auth/dbschema/default.esdl
@@ -1,0 +1,29 @@
+using extension auth;
+
+module default {
+    global current_user := (
+        assert_single((
+            select User
+            filter .identity =
+                global ext::auth::ClientTokenIdentity
+        ))
+    );
+
+    type User {
+        name: str;
+        required identity: ext::auth::Identity;
+    }
+
+    type Post {
+        required content: str;
+        required author: User;
+        access policy author_full_access
+            allow all
+            using (
+                .author ?= global current_user
+            );
+
+        access policy others_read_only
+            allow select;
+    }
+}

--- a/nodejs-auth/dbschema/migrations/00001.edgeql
+++ b/nodejs-auth/dbschema/migrations/00001.edgeql
@@ -1,0 +1,23 @@
+CREATE MIGRATION m13bcrrwlp5jdlmorad6tuv3uubb5jkbgd5f6dbhehhsbrw7jardvq
+    ONTO initial
+{
+  CREATE EXTENSION pgcrypto VERSION '1.3';
+  CREATE EXTENSION auth VERSION '1.0';
+  CREATE TYPE default::User {
+      CREATE REQUIRED LINK identity: ext::auth::Identity;
+      CREATE PROPERTY name: std::str;
+  };
+  CREATE GLOBAL default::current_user := (std::assert_single((SELECT
+      default::User
+  FILTER
+      (.identity = GLOBAL ext::auth::ClientTokenIdentity)
+  )));
+  CREATE TYPE default::Post {
+      CREATE REQUIRED LINK author: default::User;
+      CREATE ACCESS POLICY author_full_access
+          ALLOW ALL USING ((.author ?= GLOBAL default::current_user));
+      CREATE ACCESS POLICY others_read_only
+          ALLOW SELECT ;
+      CREATE REQUIRED PROPERTY content: std::str;
+  };
+};

--- a/nodejs-auth/edgedb.toml
+++ b/nodejs-auth/edgedb.toml
@@ -1,0 +1,2 @@
+[edgedb]
+server-version = "5.0"

--- a/nodejs-auth/flake.lock
+++ b/nodejs-auth/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1698869283,
+        "narHash": "sha256-EO0WZngDV6Q9xaFeHHMxuii2ayyKX4RzRrTlGF8hBiE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "747e3067461e130d9540c6a284b4e5c33fc0dde7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nodejs-auth/flake.nix
+++ b/nodejs-auth/flake.nix
@@ -1,0 +1,53 @@
+{
+  description = "A Nix-flake-based Node.js development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/master";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+      edgedb-dev = pkgs.edgedb.overrideAttrs (oldAttrs: rec {
+        version = "4.0.0-alpha.1+ddfbe70";
+        src = pkgs.fetchFromGitHub {
+          owner = "edgedb";
+          repo = "edgedb-cli";
+          rev = "243f510575f7d3fce8d1964c964dd5fdbf510299";
+          sha256 = "sha256-1G7Ci7iI8IbgWRUDPBhW9hVDR6l/VbrLJEkKzyQpIkw=";
+          fetchSubmodules = true;
+        };
+        cargoDeps = pkgs.rustPlatform.importCargoLock {
+          lockFile = src + "/Cargo.lock";
+          outputHashes = {
+            "edgedb-derive-0.5.1" = "sha256-9NhfmtuZcDG+ouDeUKM8HpboJYU8rT8Own5M13PrDU8=";
+            "edgeql-parser-0.1.0" = "sha256-c5xBuW47xXgy8VLR/P7DvVhLBd0rvI6P9w82IPPsTwo=";
+            "rexpect-0.5.0" = "sha256-vstAL/fJWWx7WbmRxNItKpzvgGF3SvJDs5isq9ym/OA=";
+            "rustyline-8.0.0" = "sha256-CrICwQbHPzS4QdVIEHxt2euX+g+0pFYe84NfMp1daEc=";
+            "serde_str-1.0.0" = "sha256-CMBh5lxdQb2085y0jc/DrV6B8iiXvVO2aoZH/lFFjak=";
+            "indexmap-2.0.0-pre" = "sha256-QMOmoUHE1F/sp+NeDpgRGqqacWLHWG02YgZc5vAdXZY=";
+          };
+        };
+      });
+    in {
+      devShell = pkgs.mkShell {
+        packages = [
+          (pkgs.nodejs_20.override {enableNpm = false;})
+          pkgs.nodePackages.npm
+          edgedb-dev
+          pkgs.httpie
+        ];
+
+        shellHook = ''
+          echo "`${edgedb-dev}/bin/edgedb --version`"
+          echo "npm `${pkgs.nodePackages.npm}/bin/npm --version`"
+          echo "node `${pkgs.nodejs_20}/bin/node --version`"
+        '';
+      };
+    });
+}

--- a/nodejs-auth/index.js
+++ b/nodejs-auth/index.js
@@ -1,0 +1,412 @@
+import http from "node:http";
+import { URL } from "node:url";
+import crypto from "node:crypto";
+
+/**
+ * You can get this value by running `edgedb instance credentials`.
+ * Value should be: `${protocol}://${host}:${port}/db/${database}/ext/auth/
+ */
+const EDGEDB_AUTH_BASE_URL = process.env.EDGEDB_AUTH_BASE_URL;
+const SERVER_PORT = 3000;
+
+/**
+ * Generate a random Base64 url-encoded string, and derive a "challenge"
+ * string from that string to use as proof that the request for a token
+ * later is made from the same user agent that made the original request
+ *
+ * @returns {Object} The verifier and challenge strings
+ */
+const generatePKCE = () => {
+  const verifier = crypto.randomBytes(32).toString("base64url");
+
+  const challenge = crypto
+    .createHash("sha256")
+    .update(verifier)
+    .digest("base64url");
+
+  return { verifier, challenge };
+};
+
+/**
+ * In Node, the `req.url` is only the `pathname` portion of a URL. In order
+ * to generate a full URL, we need to build the protocol and host from other
+ * parts of the request.
+ *
+ * One reason we like to use `URL` objects here is to easily parse the
+ * `URLSearchParams` from the request, and rather than do more error prone
+ * string manipulation, we build a `URL`.
+ *
+ * @param {Request} req
+ * @returns {URL}
+ */
+const getRequestUrl = (req) => {
+  const protocol = req.connection.encrypted ? "https" : "http";
+  return new URL(req.url, `${protocol}://${req.headers.host}`);
+};
+
+const server = http.createServer(async (req, res) => {
+  const requestUrl = getRequestUrl(req);
+
+  switch (requestUrl.pathname) {
+    case "/auth/ui/signin": {
+      await handleUiSignIn(req, res);
+      break;
+    }
+
+    case "/auth/ui/signup": {
+      await handleUiSignUp(req, res);
+      break;
+    }
+
+    case "/auth/authorize": {
+      await handleAuthorize(req, res);
+      break;
+    }
+
+    case "/auth/callback": {
+      await handleCallback(req, res);
+      break;
+    }
+
+    case "/auth/signup": {
+      await handleSignUp(req, res);
+      break;
+    }
+
+    case "/auth/signin": {
+      await handleSignIn(req, res);
+      break;
+    }
+
+    case "/auth/verify": {
+      await handleVerify(req, res);
+      break;
+    }
+
+    default: {
+      res.writeHead(404);
+      res.end("Not found");
+      break;
+    }
+  }
+});
+
+/**
+ * Redirects browser requests to EdgeDB Auth UI sign in page with the
+ * PKCE challenge, and saves PKCE verifier in an HttpOnly cookie.
+ *
+ * @param {Request} req
+ * @param {Response} res
+ */
+const handleUiSignIn = async (req, res) => {
+  const pkce = generatePKCE();
+
+  const redirectUrl = new URL("ui/signin", EDGEDB_AUTH_BASE_URL);
+  redirectUrl.searchParams.set("challenge", pkce.challenge);
+
+  res.writeHead(301, {
+    "Set-Cookie": `edgedb-pkce-verifier=${pkce.verifier}; Path=/; HttpOnly`,
+    Location: redirectUrl.href,
+  });
+  res.end();
+};
+
+/**
+ * Redirects browser requests to EdgeDB Auth UI sign up page with the
+ * PKCE challenge, and saves PKCE verifier in an HttpOnly cookie.
+ *
+ * @param {Request} req
+ * @param {Response} res
+ */
+const handleUiSignUp = async (req, res) => {
+  const pkce = generatePKCE();
+
+  const redirectUrl = new URL("ui/signup", EDGEDB_AUTH_BASE_URL);
+  redirectUrl.searchParams.set("challenge", pkce.challenge);
+
+  res.writeHead(301, {
+    "Set-Cookie": `edgedb-pkce-verifier=${pkce.verifier}; Path=/; HttpOnly`,
+    Location: redirectUrl.href,
+  });
+  res.end();
+};
+
+/**
+ * Redirects OAuth requests to EdgeDB Auth OAuth authorize redirect
+ * with the PKCE challenge, and saves PKCE verifier in an HttpOnly
+ * cookie for later retrieval.
+ *
+ * @param {Request} req
+ * @param {Response} res
+ */
+const handleAuthorize = async (req, res) => {
+  const requestUrl = getRequestUrl(req);
+  const provider = requestUrl.searchParams.get("provider");
+
+  if (!provider) {
+    res.status = 400;
+    res.end("Must provider a 'provider' value in search parameters");
+    return;
+  }
+
+  const pkce = generatePKCE();
+  const redirectUrl = new URL("authorize", EDGEDB_AUTH_BASE_URL);
+  redirectUrl.searchParams.set("provider", provider);
+  redirectUrl.searchParams.set("challenge", pkce.challenge);
+  redirectUrl.searchParams.set(
+    "redirect_to",
+    `http://localhost:{PORT}/auth/callack`,
+  );
+
+  res.writeHead(301, {
+    "Set-Cookie": `edgedb-pkce-verifier=${pkce.verifier}; Path=/; HttpOnly`,
+    Location: redirectUrl.href,
+  });
+  res.end();
+};
+
+/**
+ * Handles the PKCE callback and exchanges the `code` and `verifier
+ * for an auth_token, setting the auth_token as an HttpOnly cookie.
+ *
+ * @param {Request} req
+ * @param {Response} res
+ */
+const handleCallback = async (req, res) => {
+  const requestUrl = getRequestUrl(req);
+
+  const code = requestUrl.searchParams.get("code");
+  if (!code) {
+    const error = requestUrl.searchParams.get("error");
+    res.status = 400;
+    res.end(
+      `OAuth callback is missing 'code'. OAuth provider responded with error: ${error}`,
+    );
+    return;
+  }
+
+  const cookies = req.headers.cookie?.split("; ");
+  const verifier = cookies
+    .find((cookie) => cookie.startsWith("edgedb-pkce-verifier="))
+    ?.split("=")[1];
+  if (!verifier) {
+    res.status = 400;
+    res.end(
+      `Could not find 'verifier' in the cookie store. Is this the same user agent/browser that started the authorization flow?`,
+    );
+    return;
+  }
+
+  const codeExchangeUrl = new URL("token", EDGEDB_AUTH_BASE_URL);
+  codeExchangeUrl.searchParams.set("code", code);
+  codeExchangeUrl.searchParams.set("verifier", verifier);
+  const codeExchangeResponse = await fetch(codeExchangeUrl.href, {
+    method: "GET",
+  });
+
+  if (!codeExchangeResponse.ok) {
+    const text = await codeExchangeResponse.text();
+    res.status = 400;
+    res.end(`Error from the auth server: ${text}`);
+    return;
+  }
+
+  const { auth_token } = await codeExchangeResponse.json();
+  res.writeHead(204, {
+    "Set-Cookie": `edgedb-auth-token=${auth_token}; Path=/; HttpOnly`,
+  });
+  res.end();
+};
+
+/**
+ * Handles sign up with email and password.
+ *
+ * @param {Request} req
+ * @param {Response} res
+ */
+const handleSignUp = async (req, res) => {
+  let body = "";
+  req.on("data", (chunk) => {
+    body += chunk.toString();
+  });
+  req.on("end", async () => {
+    const pkce = generatePKCE();
+    const { email, password, provider } = JSON.parse(body);
+    if (!email || !password || !provider) {
+      res.status = 400;
+      res.end(
+        `Request body malformed. Expected JSON body with 'email', 'password', and 'provider' keys, but got: ${body}`,
+      );
+      return;
+    }
+
+    const registerUrl = new URL("register", EDGEDB_AUTH_BASE_URL);
+    const registerResponse = await fetch(registerUrl.href, {
+      method: "post",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        challenge: pkce.challenge,
+        email,
+        password,
+        provider,
+        verify_url: `http://localhost:${SERVER_PORT}/auth/verify`,
+      }),
+    });
+
+    if (!registerResponse.ok) {
+      const text = await registerResponse.text();
+      res.status = 400;
+      res.end(`Error from the auth server: ${text}`);
+      return;
+    }
+
+    res.writeHead(204, {
+      "Set-Cookie": `edgedb-pkce-verifier=${pkce.verifier}; Path=/; HttpOnly`,
+    });
+    res.end();
+  });
+};
+/**
+ * Handles sign in with email and password.
+ *
+ * @param {Request} req
+ * @param {Response} res
+ */
+const handleSignIn = async (req, res) => {
+  let body = "";
+  req.on("data", (chunk) => {
+    body += chunk.toString();
+  });
+  req.on("end", async () => {
+    const pkce = generatePKCE();
+    const { email, password, provider } = JSON.parse(body);
+    if (!email || !password || !provider) {
+      res.status = 400;
+      res.end(
+        `Request body malformed. Expected JSON body with 'email', 'password', and 'provider' keys, but got: ${body}`,
+      );
+      return;
+    }
+
+    const authenticateUrl = new URL("authenticate", EDGEDB_AUTH_BASE_URL);
+    const authenticateResponse = await fetch(authenticateUrl.href, {
+      method: "post",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        challenge: pkce.challenge,
+        email,
+        password,
+        provider,
+      }),
+    });
+
+    if (!authenticateResponse.ok) {
+      const text = await authenticateResponse.text();
+      res.status = 400;
+      res.end(`Error from the auth server: ${text}`);
+      return;
+    }
+
+    const { code } = await authenticateResponse.json();
+
+    const tokenUrl = new URL("token", EDGEDB_AUTH_BASE_URL);
+    tokenUrl.searchParams.set("code", code);
+    tokenUrl.searchParams.set("verifier", pkce.verifier);
+    const tokenResponse = await fetch(tokenUrl.href, {
+      method: "get",
+    });
+
+    if (!tokenResponse.ok) {
+      const text = await authenticateResponse.text();
+      res.status = 400;
+      res.end(`Error from the auth server: ${text}`);
+      return;
+    }
+
+    const { auth_token } = await tokenResponse.json();
+    res.writeHead(204, {
+      "Set-Cookie": `edgedb-auth-token=${auth_token}; Path=/; HttpOnly`,
+    });
+    res.end();
+  });
+};
+
+/**
+ * Handles the link in the email verification flow.
+ *
+ * @param {Request} req
+ * @param {Response} res
+ */
+const handleVerify = async (req, res) => {
+  const requestUrl = getRequestUrl(req);
+  const verification_token = requestUrl.searchParams.get("verification_token");
+  if (!verification_token) {
+    res.status = 400;
+    res.end(
+      `Verify request is missing 'verification_token' search param. The verification email is malformed.`,
+    );
+    return;
+  }
+
+  const cookies = req.headers.cookie?.split("; ");
+  const verifier = cookies
+    .find((cookie) => cookie.startsWith("edgedb-pkce-verifier="))
+    ?.split("=")[1];
+  if (!verifier) {
+    res.status = 400;
+    res.end(
+      `Could not find 'verifier' in the cookie store. Is this the same user agent/browser that started the authorization flow?`,
+    );
+    return;
+  }
+
+  const verifyUrl = new URL("verify", EDGEDB_AUTH_BASE_URL);
+  const verifyResponse = await fetch(verifyUrl.href, {
+    method: "post",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      verification_token,
+      verifier,
+      provider: "builtin::local_emailpassword",
+    }),
+  });
+
+  if (!verifyResponse.ok) {
+    const text = await verifyResponse.text();
+    res.status = 400;
+    res.end(`Error from the auth server: ${text}`);
+    return;
+  }
+
+  const { code } = await verifyResponse.json();
+
+  const tokenUrl = new URL("token", EDGEDB_AUTH_BASE_URL);
+  tokenUrl.searchParams.set("code", code);
+  tokenUrl.searchParams.set("verifier", verifier);
+  const tokenResponse = await fetch(tokenUrl.href, {
+    method: "get",
+  });
+
+  if (!tokenResponse.ok) {
+    const text = await authenticateResponse.text();
+    res.status = 400;
+    res.end(`Error from the auth server: ${text}`);
+    return;
+  }
+
+  const { auth_token } = await tokenResponse.json();
+  res.writeHead(204, {
+    "Set-Cookie": `edgedb-auth-token=${auth_token}; Path=/; HttpOnly`,
+  });
+  res.end();
+};
+
+server.listen(SERVER_PORT, () => {
+  console.log(`HTTP server listening on port ${SERVER_PORT}...`);
+});

--- a/nodejs-auth/package-lock.json
+++ b/nodejs-auth/package-lock.json
@@ -1,0 +1,45 @@
+{
+  "name": "auth-nodejs-example",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "auth-nodejs-example",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "edgedb": "^1.4.0"
+      },
+      "devDependencies": {
+        "prettier": "^3.0.3"
+      }
+    },
+    "node_modules/edgedb": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/edgedb/-/edgedb-1.4.0.tgz",
+      "integrity": "sha512-KYH0DDaOlOe0EZEy9TYbVIM7LHZo5+wAsvmtFT7QoYm8ukaTQhEGSVQ8STMvGLRGPrUUJyEqS3C+P2gO0NvdCA==",
+      "bin": {
+        "edgeql-js": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
+      "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/nodejs-auth/package.json
+++ b/nodejs-auth/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "auth-nodejs-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "",
+  "type": "module",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+  },
+  "dependencies": {
+    "edgedb": "^1.4.0"
+  },
+  "devDependencies": {
+    "prettier": "^3.0.3"
+  }
+}


### PR DESCRIPTION
To accompany the [EdgeDB Auth Guide](https://www.edgedb.com/docs/guides/auth/index), this is an example of a complete stock NodeJS HTTP server that exercises the EdgeDB Auth extension.

TODO in future effort:
- Show protecting a route by looking for the cookie
- Show making an authenticated (access policy) query using the auth token
- Add a simple-as-possible HTML interface