### PR TITLE
Add EdgeDB Auth + Express example app

### DIFF
--- a/express-auth/.gitignore
+++ b/express-auth/.gitignore
@@ -1,0 +1,39 @@
+#########################################
+# TypeScript / JS / NodeJS
+#########################################
+
+# dependencies
+/node_modules
+/.pnp
+.pnp.js
+
+# testing
+/coverage
+
+# next.js
+/.next/
+/out/
+
+# production
+/build
+
+# misc
+.DS_Store
+*.pem
+
+# debug
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# local env files
+.env.development.local
+.env.test.local
+.env.production.local
+
+# vercel
+.vercel
+
+*.db
+
+dbschema/edgeql-js

--- a/express-auth/README.md
+++ b/express-auth/README.md
@@ -8,13 +8,13 @@
 1. Run `edgedb project init`and follow the prompts
 2. Run `npm install`
 3. Run `edgedb ui`
-4. Switch to the "Auth Admin" section (nested shield icon in the left-hand toolbar)
+4. Click into the `edgedb` database and switch to the "Auth Admin" section (nested shield icon in the left-hand toolbar)
 5. Enter a value for `auth_signing_key` or click the button nested in the field to generate one and click the "Update" button
 6. Enter `http://localhost:3333/` in the `allowed_redirect_urls` field and click "Update"
 7. Switch to the "Providers" tab
 8. Click "Add Provider," select and configure a provider, and click "Add Provider" to save the new provider
-9. Set the value for `redirect_to` to `http://localhost:3333/auth/callback` and click "Update"
-10. (Built-in only) Click "Enable" under "Login UI"
+9. (Built-in only) Click "Enable" under "Login UI"
+10. (Built-in only) Set the value for `redirect_to` to `http://localhost:3333/auth/callback` and click "Update"
 
 > Note: If you configured the "Email + Password" provider to require verification, the example app will need a way to send emails. You might try running Mailpit to do this for local testing. We share how [in our EdgeDB Auth guide](https://www.edgedb.com/docs/guides/auth/index#email-and-password).
 

--- a/express-auth/README.md
+++ b/express-auth/README.md
@@ -2,3 +2,12 @@
 
 - `builtin.ts` shows how to use the built-in UI using the route factory method.
 - `custom.ts` shows how to build your own UI using the manual router method.
+
+## Usage
+
+```bash
+npm install
+npm run builtin
+# or
+npm run custom
+```

--- a/express-auth/README.md
+++ b/express-auth/README.md
@@ -1,0 +1,4 @@
+# Express with EdgeDB Auth
+
+- `builtin.ts` shows how to use the built-in UI using the route factory method.
+- `custom.ts` shows how to build your own UI using the manual router method.

--- a/express-auth/README.md
+++ b/express-auth/README.md
@@ -3,11 +3,24 @@
 - `builtin.ts` shows how to use the built-in UI using the route factory method.
 - `custom.ts` shows how to build your own UI using the manual router method.
 
+## Setup
+
+1. Run `edgedb project init`and follow the prompts
+2. Run `npm install`
+3. Run `edgedb ui`
+4. Switch to the "Auth Admin" section (nested shield icon in the left-hand toolbar)
+5. Enter a value for `auth_signing_key` or click the button nested in the field to generate one and click the "Update" button
+6. Enter `http://localhost:3333/` in the `allowed_redirect_urls` field and click "Update"
+7. Switch to the "Providers" tab
+8. Click "Add Provider," select and configure a provider, and click "Add Provider" to save the new provider
+9. Set the value for `redirect_to` to `http://localhost:3333/auth/callback` and click "Update"
+10. (Built-in only) Click "Enable" under "Login UI"
+
+> Note: If you configured the "Email + Password" provider to require verification, the example app will need a way to send emails. You might try running Mailpit to do this for local testing. We share how [in our EdgeDB Auth guide](https://www.edgedb.com/docs/guides/auth/index#email-and-password).
+
 ## Usage
 
 ```bash
-npm install
 npm run builtin
 # or
 npm run custom
-```

--- a/express-auth/auth.ts
+++ b/express-auth/auth.ts
@@ -35,6 +35,18 @@ export const signoutRoute = Router().get(
   }
 );
 
+export const factoriedBuiltinUIRouter = auth.createBuiltinRouter({
+  callback: [
+    async (req: CallbackRequest, res: Response) => {
+      if (req.isSignUp) {
+        return res.redirect("/onboarding");
+      }
+
+      res.redirect("/");
+    },
+  ],
+});
+
 export const factoriedEmailPasswordRouter = auth.createEmailPasswordRouter("/auth", {
   signIn: [
     async (_: AuthRequest, res: Response) => {

--- a/express-auth/auth.ts
+++ b/express-auth/auth.ts
@@ -1,0 +1,114 @@
+import {
+  type NextFunction,
+  type Request,
+  type Response,
+  Router,
+} from "express";
+import createExpressAuth, {
+  AuthRequest,
+  ExpressAuthSession,
+} from "@edgedb/auth-express";
+import { client } from "./db";
+
+export const auth = createExpressAuth(client, {
+  baseUrl: "http://localhost:3333",
+});
+
+export const requireAuth = async (
+  req: AuthRequest,
+  res: Response<any, { session?: ExpressAuthSession }>,
+  next: NextFunction
+) => {
+  if (!(await req.session?.isLoggedIn())) {
+    res.redirect("/signin");
+  } else {
+    next();
+  }
+};
+
+export const authEmailPasswordRouter = Router()
+  .post(
+    "/signin",
+    auth.emailPassword.signIn,
+    async (_: AuthRequest, res: Response, __: NextFunction) => {
+      res.redirect("/");
+    },
+    (err: any, req: Request, res: Response, next: NextFunction) => {
+      console.error("/signin error: ", err);
+      res.redirect(`/signin?error=${encodeURIComponent(err.message)}`);
+    }
+  )
+  .post(
+    "/signup",
+    auth.emailPassword.signUp,
+    async (req: AuthRequest, res: Response, __: NextFunction) => {
+      if (!req.tokenData?.identity_id) {
+        throw new Error("Not logged in");
+      }
+
+      await client.query(
+        `insert User {
+          identity := assert_exists(assert_single(
+            (select ext::auth::Identity filter .id = <uuid>$identity_id)
+          ))
+        }`,
+        { identity_id: req.tokenData.identity_id }
+      );
+      res.redirect("/onboarding");
+    },
+    (err: any, req: Request, res: Response, next: NextFunction) => {
+      console.error("/signup error: ", err);
+      res.redirect(`/signin?error=${encodeURIComponent(err.message)}`);
+    }
+  )
+  .get(
+    "/verify",
+    auth.emailPassword.verify,
+    async (_: AuthRequest, res: Response, __: NextFunction) => {
+      res.redirect("/onboarding");
+    },
+    (err: any, req: Request, res: Response, next: NextFunction) => {
+      console.error("/verify error: ", err);
+      res.redirect(`/verify?error=${encodeURIComponent(err.message)}`);
+    }
+  )
+  .post(
+    "/send-password-reset-email",
+    auth.emailPassword.sendPasswordResetEmail,
+    async (_: AuthRequest, res: Response, __: NextFunction) => {
+      res.redirect("/signin");
+    },
+    (err: any, req: Request, res: Response, next: NextFunction) => {
+      console.error("/send-password-reset-email error: ", err);
+      res.redirect(`/signin?error=${encodeURIComponent(err.message)}`);
+    }
+  )
+  .post(
+    "/reset-password",
+    auth.emailPassword.resetPassword,
+    async (_: AuthRequest, res: Response, __: NextFunction) => {
+      res.redirect("/");
+    },
+    async (err: any, req: Request, res: Response, next: NextFunction) => {
+      console.error("/reset-password error: ", err);
+      res.redirect(`/signin?error=${encodeURIComponent(err.message)}`);
+    }
+  )
+  .post(
+    "/resend-verification-email",
+    auth.emailPassword.resendVerificationEmail,
+    async (_: AuthRequest, res: Response, __: NextFunction) => {
+      res.redirect("/signin");
+    },
+    async (err: any, req: Request, res: Response, next: NextFunction) => {
+      console.error("/resent-verification-email error: ", err);
+      res.redirect(`/signin?error=${encodeURIComponent(err.message)}`);
+    }
+  )
+  .get(
+    "/signout",
+    auth.signout,
+    async (_: AuthRequest, res: Response, __: NextFunction) => {
+      res.redirect("/");
+    }
+  );

--- a/express-auth/auth.ts
+++ b/express-auth/auth.ts
@@ -5,11 +5,11 @@ import {
   Router,
 } from "express";
 import createExpressAuth, {
-  AuthRequest,
-  CallbackRequest,
-  ExpressAuthSession,
+  type AuthRequest,
+  type CallbackRequest,
+  type ExpressAuthSession,
 } from "@edgedb/auth-express";
-import { client } from "./db";
+import { client } from "./db.js";
 
 export const auth = createExpressAuth(client, {
   baseUrl: "http://localhost:3333",

--- a/express-auth/auth.ts
+++ b/express-auth/auth.ts
@@ -148,7 +148,7 @@ export const emailPasswordRouter = Router()
   .post("/signin", auth.emailPassword.signIn, ...emailPassword.signIn)
   .post(
     "/signup",
-    auth.emailPassword.signUp("http://localhost:3333/auth/verify"),
+    auth.emailPassword.signUp("http://localhost:3333/auth/email-password/verify"),
     ...emailPassword.signUp
   )
   .get("/verify", auth.emailPassword.verify, ...emailPassword.verify)

--- a/express-auth/auth.ts
+++ b/express-auth/auth.ts
@@ -26,8 +26,17 @@ export const requireAuth = async (
   }
 };
 
-export const configuredEmailPasswordRouter = auth
-  .createEmailPasswordRouter("/auth", {
+export const logoutRoute = Router().get(
+  "/",
+  auth.signout,
+  async (_: AuthRequest, res: Response, __: NextFunction) => {
+    res.redirect("/");
+  }
+);
+
+export const configuredEmailPasswordRouter = auth.createEmailPasswordRouter(
+  "/auth",
+  {
     signIn: [
       async (_: AuthRequest, res: Response, __: NextFunction) => {
         res.redirect("/");
@@ -94,14 +103,8 @@ export const configuredEmailPasswordRouter = auth
         res.redirect(`/signin?error=${encodeURIComponent(err.message)}`);
       },
     ],
-  })
-  .get(
-    "/signout",
-    auth.signout,
-    async (_: AuthRequest, res: Response, __: NextFunction) => {
-      res.redirect("/");
-    }
-  );
+  }
+);
 
 export const authEmailPasswordRouter = Router()
   .post(
@@ -182,12 +185,5 @@ export const authEmailPasswordRouter = Router()
     async (err: any, req: Request, res: Response, next: NextFunction) => {
       console.error("/resent-verification-email error: ", err);
       res.redirect(`/signin?error=${encodeURIComponent(err.message)}`);
-    }
-  )
-  .get(
-    "/signout",
-    auth.signout,
-    async (_: AuthRequest, res: Response, __: NextFunction) => {
-      res.redirect("/");
     }
   );

--- a/express-auth/auth.ts
+++ b/express-auth/auth.ts
@@ -19,12 +19,89 @@ export const requireAuth = async (
   res: Response<any, { session?: ExpressAuthSession }>,
   next: NextFunction
 ) => {
-  if (!(await req.session?.isLoggedIn())) {
+  if (!(await req.session?.isSignedIn())) {
     res.redirect("/signin");
   } else {
     next();
   }
 };
+
+export const configuredEmailPasswordRouter = auth
+  .createEmailPasswordRouter("/auth", {
+    signIn: [
+      async (_: AuthRequest, res: Response, __: NextFunction) => {
+        res.redirect("/");
+      },
+      (err: any, req: Request, res: Response, next: NextFunction) => {
+        console.error("/signin error: ", err);
+        res.redirect(`/signin?error=${encodeURIComponent(err.message)}`);
+      },
+    ],
+    signUp: [
+      async (req: AuthRequest, res: Response, __: NextFunction) => {
+        if (!req.tokenData?.identity_id) {
+          throw new Error("Not logged in");
+        }
+
+        await client.query(
+          `insert User {
+          identity := assert_exists(assert_single(
+            (select ext::auth::Identity filter .id = <uuid>$identity_id)
+          ))
+        }`,
+          { identity_id: req.tokenData.identity_id }
+        );
+        res.redirect("/onboarding");
+      },
+      (err: any, req: Request, res: Response, next: NextFunction) => {
+        console.error("/signup error: ", err);
+        res.redirect(`/signin?error=${encodeURIComponent(err.message)}`);
+      },
+    ],
+    verify: [
+      async (_: AuthRequest, res: Response, __: NextFunction) => {
+        res.redirect("/onboarding");
+      },
+      (err: any, req: Request, res: Response, next: NextFunction) => {
+        console.error("/verify error: ", err);
+        res.redirect(`/verify?error=${encodeURIComponent(err.message)}`);
+      },
+    ],
+    resendVerificationEmail: [
+      async (_: AuthRequest, res: Response, __: NextFunction) => {
+        res.redirect("/signin");
+      },
+      async (err: any, req: Request, res: Response, next: NextFunction) => {
+        console.error("/resent-verification-email error: ", err);
+        res.redirect(`/signin?error=${encodeURIComponent(err.message)}`);
+      },
+    ],
+    resetPassword: [
+      async (_: AuthRequest, res: Response, __: NextFunction) => {
+        res.redirect("/");
+      },
+      async (err: any, req: Request, res: Response, next: NextFunction) => {
+        console.error("/reset-password error: ", err);
+        res.redirect(`/signin?error=${encodeURIComponent(err.message)}`);
+      },
+    ],
+    sendPasswordResetEmail: [
+      async (_: AuthRequest, res: Response, __: NextFunction) => {
+        res.redirect("/signin");
+      },
+      (err: any, req: Request, res: Response, next: NextFunction) => {
+        console.error("/send-password-reset-email error: ", err);
+        res.redirect(`/signin?error=${encodeURIComponent(err.message)}`);
+      },
+    ],
+  })
+  .get(
+    "/signout",
+    auth.signout,
+    async (_: AuthRequest, res: Response, __: NextFunction) => {
+      res.redirect("/");
+    }
+  );
 
 export const authEmailPasswordRouter = Router()
   .post(
@@ -40,7 +117,7 @@ export const authEmailPasswordRouter = Router()
   )
   .post(
     "/signup",
-    auth.emailPassword.signUp,
+    auth.emailPassword.signUp("http://localhost:3333/auth/verify"),
     async (req: AuthRequest, res: Response, __: NextFunction) => {
       if (!req.tokenData?.identity_id) {
         throw new Error("Not logged in");
@@ -74,7 +151,9 @@ export const authEmailPasswordRouter = Router()
   )
   .post(
     "/send-password-reset-email",
-    auth.emailPassword.sendPasswordResetEmail,
+    auth.emailPassword.sendPasswordResetEmail(
+      "http://localhost:3333/auth/reset-password"
+    ),
     async (_: AuthRequest, res: Response, __: NextFunction) => {
       res.redirect("/signin");
     },

--- a/express-auth/auth.ts
+++ b/express-auth/auth.ts
@@ -27,7 +27,7 @@ export const requireAuth = async (
   }
 };
 
-/************ 
+/************
  * Sign Out *
  ************/
 
@@ -39,7 +39,7 @@ export const signoutRoute = Router().get(
   }
 );
 
-/*************** 
+/***************
  * Built-in UI *
  ***************/
 

--- a/express-auth/auth.ts
+++ b/express-auth/auth.ts
@@ -135,6 +135,7 @@ const emailPassword = {
 
 export const factoriedEmailPasswordRouter = auth.createEmailPasswordRouter(
   "/auth",
+  "/reset-password",
   emailPassword
 );
 

--- a/express-auth/auth.ts
+++ b/express-auth/auth.ts
@@ -77,7 +77,12 @@ const emailPassword = {
   signUp: [
     async (req: AuthRequest, res: Response) => {
       if (!req.tokenData?.identity_id) {
-        throw new Error("Not logged in");
+        // Requires email validation
+        return res.redirect(
+          `/signin?error=${encodeURIComponent(
+            "Check your email for verification instructions."
+          )}`
+        );
       }
 
       await client.query(

--- a/express-auth/builtin.ts
+++ b/express-auth/builtin.ts
@@ -1,0 +1,77 @@
+import express from "express";
+import cookieParser from "cookie-parser";
+import { type AuthRequest } from "@edgedb/auth-express";
+
+import { styles } from "./styles";
+import {
+  auth,
+  requireAuth,
+  signoutRoute,
+  factoriedBuiltinUIRouter,
+} from "./auth";
+import { router as todosRouter } from "./todos";
+
+const app = express();
+
+app.use(express.json());
+app.use(express.urlencoded({ extended: false }));
+app.use(cookieParser());
+app.use(auth.createSessionMiddleware());
+
+app.use("/api/todos", todosRouter);
+
+app.use("/auth", factoriedBuiltinUIRouter);
+app.use("/auth/signout", signoutRoute);
+
+const pageTemplate = (body: string) => `
+<html>
+  <head>
+    <style>
+${styles}
+    </style>
+  </head>
+  <body>
+    <main>
+${body}
+    </main>
+  </body>
+</html>
+`;
+
+app.get("/onboarding", requireAuth, (req, res) => {
+  res.send(
+    pageTemplate(`
+    <h1>Onboarding</h1>
+    <a href="/auth/signout">Sign out</a>
+  `)
+  );
+});
+
+app.get("/dashboard", requireAuth, (req, res) => {
+  res.send(
+    pageTemplate(`
+    <h1>Dashboard</h1>
+    <a href="/auth/signout">Sign out</a>
+  `)
+  );
+});
+
+app.get("/verify", (req, res) => {
+  res.send(
+    pageTemplate(`
+    <p>Check your email for a verification message.</p>
+  `)
+  );
+});
+
+app.get("/signin", (_, res) => {
+  res.redirect("/auth/signin");
+});
+
+app.get("/", requireAuth, async (req: AuthRequest, res) => {
+  res.redirect("/dashboard");
+});
+
+app.listen(3333, () => {
+  console.log("Listening on http://localhost:3333");
+});

--- a/express-auth/builtin.ts
+++ b/express-auth/builtin.ts
@@ -2,14 +2,14 @@ import express from "express";
 import cookieParser from "cookie-parser";
 import { type AuthRequest } from "@edgedb/auth-express";
 
-import { styles } from "./styles";
+import { styles } from "./styles.js";
 import {
   auth,
   requireAuth,
   signoutRoute,
   factoriedBuiltinUIRouter,
-} from "./auth";
-import { router as todosRouter } from "./todos";
+} from "./auth.js";
+import { router as todosRouter } from "./todos.js";
 
 const app = express();
 

--- a/express-auth/custom.ts
+++ b/express-auth/custom.ts
@@ -2,15 +2,15 @@ import express from "express";
 import cookieParser from "cookie-parser";
 import { AuthRequest } from "@edgedb/auth-express";
 
-import { styles } from "./styles";
+import { styles } from "./styles.js";
 import {
   auth,
   requireAuth,
   emailPasswordRouter,
   oAuthRouter,
   signoutRoute,
-} from "./auth";
-import { router as todosRouter } from "./todos";
+} from "./auth.js";
+import { router as todosRouter } from "./todos.js";
 
 const app = express();
 

--- a/express-auth/custom.ts
+++ b/express-auth/custom.ts
@@ -87,7 +87,7 @@ app.get("/signin", async (req, res) => {
     <div>
       ${oAuthProviderButtons.join("")}
     </div>
-    <form method="POST" action="/auth/signin">
+    <form method="POST" action="/auth/email-password/signin">
       <div class="form-control">
         <label for="email">Email:</label>
         <input type="email" id="email" name="email" placeholder="email@example.com" autofocus />
@@ -98,7 +98,7 @@ app.get("/signin", async (req, res) => {
       </div>
       <div class="actions">
         <button type="submit">Sign In</button>
-        <button type="submit" formaction="/auth/signup">Sign Up</button>
+        <button type="submit" formaction="/auth/email-password/signup">Sign Up</button>
       </div>
     </form>
     <a href="/forgot-password">Forgot your password?</a>
@@ -110,7 +110,7 @@ app.get("/forgot-password", (req, res) => {
   res.send(
     pageTemplate(`
     <h1>Forgot Password</h1>
-    <form method="POST" action="/auth/send-password-reset-email">
+    <form method="POST" action="/auth/email-password/send-password-reset-email">
       <div class="form-control">
         <label for="email">Email:</label>
         <input type="email" id="email" name="email" placeholder="email@example.com" autofocus />

--- a/express-auth/custom.ts
+++ b/express-auth/custom.ts
@@ -6,12 +6,11 @@ import { styles } from "./styles";
 import {
   auth,
   requireAuth,
-  factoriedEmailPasswordRouter,
-  signoutRoute,
+  emailPasswordRouter,
   oAuthRouter,
-  factoriedBuiltinUIRouter,
-  factoriedOAuthRouter,
+  signoutRoute,
 } from "./auth";
+import { router as todosRouter } from "./todos";
 
 const app = express();
 
@@ -20,9 +19,10 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(auth.createSessionMiddleware());
 
-app.use(factoriedEmailPasswordRouter);
-app.use(factoriedOAuthRouter);
-app.use("/auth", factoriedBuiltinUIRouter);
+app.use("/api/todos", todosRouter);
+
+app.use("/auth/email-password", emailPasswordRouter);
+app.use("/auth/oauth", oAuthRouter);
 app.use("/auth/signout", signoutRoute);
 
 const pageTemplate = (body: string) => `
@@ -66,11 +66,6 @@ app.get("/verify", (req, res) => {
   );
 });
 
-app.get("/signin", (_, res) => {
-  res.redirect("/auth/signin");
-});
-
-/*
 app.get("/signin", async (req, res) => {
   const url = new URL(req.url, `http://${req.headers.host}`);
   const errors = url.searchParams.getAll("error");
@@ -128,7 +123,6 @@ app.get("/forgot-password", (req, res) => {
   `)
   );
 });
-*/
 
 app.get("/", requireAuth, async (req: AuthRequest, res) => {
   res.redirect("/dashboard");

--- a/express-auth/db.ts
+++ b/express-auth/db.ts
@@ -1,0 +1,3 @@
+import { createClient } from "edgedb";
+
+export const client = createClient();

--- a/express-auth/dbschema/default.esdl
+++ b/express-auth/dbschema/default.esdl
@@ -2,6 +2,30 @@ using extension auth;
 
 module default {
   type User {
-    required identity: ext::auth::Identity;
-  }
+    required identity: ext::auth::Identity {
+      constraint exclusive;
+    };
+    name: str;
+  };
+
+  global currentUser := (
+    select User filter .identity = global ext::auth::ClientTokenIdentity
+  );
+
+  type Todo {
+    required owner: User {
+      default := global currentUser;
+    };
+    required content: str;
+    required created_on: datetime {
+      default := datetime_current();
+    };
+    required completed: bool {
+      default := false;
+    };
+
+    access policy ownerHasAccess
+      allow all
+      using (global currentUser ?= .owner);
+  };
 }

--- a/express-auth/dbschema/default.esdl
+++ b/express-auth/dbschema/default.esdl
@@ -1,0 +1,7 @@
+using extension auth;
+
+module default {
+  type User {
+    required identity: ext::auth::Identity;
+  }
+}

--- a/express-auth/dbschema/migrations/00001.edgeql
+++ b/express-auth/dbschema/migrations/00001.edgeql
@@ -1,0 +1,9 @@
+CREATE MIGRATION m1pht25sdxgo7tw3loovimnppi7v6schpwpp2moqirw2seuib66r6a
+    ONTO initial
+{
+  CREATE EXTENSION pgcrypto VERSION '1.3';
+  CREATE EXTENSION auth VERSION '1.0';
+  CREATE TYPE default::User {
+      CREATE REQUIRED LINK identity: ext::auth::Identity;
+  };
+};

--- a/express-auth/dbschema/migrations/00002.edgeql
+++ b/express-auth/dbschema/migrations/00002.edgeql
@@ -1,0 +1,29 @@
+CREATE MIGRATION m1ybrsc7aeu7w44f3x5jyzatdykxgj3jbtn7zzkavewfycgapm5hla
+    ONTO m1pht25sdxgo7tw3loovimnppi7v6schpwpp2moqirw2seuib66r6a
+{
+  ALTER TYPE default::User {
+      ALTER LINK identity {
+          CREATE CONSTRAINT std::exclusive;
+      };
+      CREATE PROPERTY name: std::str;
+  };
+  CREATE GLOBAL default::currentUser := (SELECT
+      default::User
+  FILTER
+      (.identity = GLOBAL ext::auth::ClientTokenIdentity)
+  );
+  CREATE TYPE default::Todo {
+      CREATE REQUIRED LINK owner: default::User {
+          SET default := (GLOBAL default::currentUser);
+      };
+      CREATE ACCESS POLICY ownerHasAccess
+          ALLOW ALL USING ((GLOBAL default::currentUser ?= .owner));
+      CREATE REQUIRED PROPERTY completed: std::bool {
+          SET default := false;
+      };
+      CREATE REQUIRED PROPERTY content: std::str;
+      CREATE REQUIRED PROPERTY created_on: std::datetime {
+          SET default := (std::datetime_current());
+      };
+  };
+};

--- a/express-auth/edgedb.toml
+++ b/express-auth/edgedb.toml
@@ -1,0 +1,2 @@
+[edgedb]
+server-version = "4.2"

--- a/express-auth/index.ts
+++ b/express-auth/index.ts
@@ -3,16 +3,16 @@ import cookieParser from "cookie-parser";
 import { AuthRequest } from "@edgedb/auth-express/src";
 
 import { styles } from "./styles";
-import { auth, requireAuth, authEmailPasswordRouter } from "./auth";
+import { auth, requireAuth, configuredEmailPasswordRouter } from "./auth";
 
 const app = express();
 
 app.use(express.json());
-app.use(express.urlencoded());
+app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(auth.createSessionMiddleware());
 
-app.use("/auth", authEmailPasswordRouter);
+app.use("/auth", configuredEmailPasswordRouter);
 
 const pageTemplate = (body: string) => `
 <html>
@@ -103,12 +103,8 @@ app.get("/forgot-password", (req, res) => {
   );
 });
 
-app.get("/", async (req: AuthRequest, res) => {
-  if (await req.session?.isLoggedIn()) {
-    res.redirect("/dashboard");
-  } else {
-    res.redirect("/signin");
-  }
+app.get("/", requireAuth, async (req: AuthRequest, res) => {
+  res.redirect("/dashboard");
 });
 
 app.listen(3333, () => {

--- a/express-auth/index.ts
+++ b/express-auth/index.ts
@@ -1,0 +1,116 @@
+import express from "express";
+import cookieParser from "cookie-parser";
+import { AuthRequest } from "@edgedb/auth-express/src";
+
+import { styles } from "./styles";
+import { auth, requireAuth, authEmailPasswordRouter } from "./auth";
+
+const app = express();
+
+app.use(express.json());
+app.use(express.urlencoded());
+app.use(cookieParser());
+app.use(auth.createSessionMiddleware());
+
+app.use("/auth", authEmailPasswordRouter);
+
+const pageTemplate = (body: string) => `
+<html>
+  <head>
+    <style>
+${styles}
+    </style>
+  </head>
+  <body>
+    <main>
+${body}
+    </main>
+  </body>
+</html>
+`;
+
+app.get("/onboarding", requireAuth, (req, res) => {
+  res.send(
+    pageTemplate(`
+    <h1>Onboarding</h1>
+    <a href="/auth/signout">Sign out</a>
+  `)
+  );
+});
+
+app.get("/dashboard", requireAuth, (req, res) => {
+  res.send(
+    pageTemplate(`
+    <h1>Dashboard</h1>
+    <a href="/auth/signout">Sign out</a>
+  `)
+  );
+});
+
+app.get("/verify", (req, res) => {
+  res.send(
+    pageTemplate(`
+    <p>Check your email for a verification message.</p>
+  `)
+  );
+});
+
+app.get("/signin", (req, res) => {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const errors = url.searchParams.getAll("error");
+  const errorMessages = errors.map((error) => `<p class="error">${error}</p>`);
+
+  res.send(
+    pageTemplate(`
+    <h1>Welcome!</h1>
+    <div class="errors">
+      ${errorMessages.join("")}
+    </div>
+    <form method="POST" action="/auth/signin">
+      <div class="form-control">
+        <label for="email">Email:</label>
+        <input type="email" id="email" name="email" placeholder="email@example.com" autofocus />
+      </div>
+      <div class="form-control">
+        <label for="password">Password:</label>
+        <input type="password" id="password" name="password" />
+      </div>
+      <div class="actions">
+        <button type="submit">Sign In</button>
+        <button type="submit" formaction="/auth/signup">Sign Up</button>
+      </div>
+    </form>
+    <a href="/forgot-password">Forgot your password?</a>
+  `)
+  );
+});
+
+app.get("/forgot-password", (req, res) => {
+  res.send(
+    pageTemplate(`
+    <h1>Forgot Password</h1>
+    <form method="POST" action="/auth/send-password-reset-email">
+      <div class="form-control">
+        <label for="email">Email:</label>
+        <input type="email" id="email" name="email" placeholder="email@example.com" autofocus />
+      </div>
+      <div class="actions">
+        <button type="submit">Send Password Reset Email</button>
+        <a href="/signin">Cancel</a>
+      </div>
+    </form>
+  `)
+  );
+});
+
+app.get("/", async (req: AuthRequest, res) => {
+  if (await req.session?.isLoggedIn()) {
+    res.redirect("/dashboard");
+  } else {
+    res.redirect("/signin");
+  }
+});
+
+app.listen(3333, () => {
+  console.log("Listening on http://localhost:3333");
+});

--- a/express-auth/index.ts
+++ b/express-auth/index.ts
@@ -3,7 +3,12 @@ import cookieParser from "cookie-parser";
 import { AuthRequest } from "@edgedb/auth-express/src";
 
 import { styles } from "./styles";
-import { auth, requireAuth, configuredEmailPasswordRouter } from "./auth";
+import {
+  auth,
+  requireAuth,
+  configuredEmailPasswordRouter,
+  logoutRoute,
+} from "./auth";
 
 const app = express();
 
@@ -13,6 +18,7 @@ app.use(cookieParser());
 app.use(auth.createSessionMiddleware());
 
 app.use(configuredEmailPasswordRouter);
+app.use("/auth/logout", logoutRoute);
 
 const pageTemplate = (body: string) => `
 <html>

--- a/express-auth/index.ts
+++ b/express-auth/index.ts
@@ -9,6 +9,8 @@ import {
   factoriedEmailPasswordRouter,
   signoutRoute,
   oAuthRouter,
+  factoriedBuiltinUIRouter,
+  factoriedOAuthRouter,
 } from "./auth";
 
 const app = express();
@@ -19,7 +21,8 @@ app.use(cookieParser());
 app.use(auth.createSessionMiddleware());
 
 app.use(factoriedEmailPasswordRouter);
-app.use("/auth/oauth", oAuthRouter);
+app.use(factoriedOAuthRouter);
+app.use("/auth", factoriedBuiltinUIRouter);
 app.use("/auth/signout", signoutRoute);
 
 const pageTemplate = (body: string) => `
@@ -63,6 +66,11 @@ app.get("/verify", (req, res) => {
   );
 });
 
+app.get("/signin", (_, res) => {
+  res.redirect("/auth/signin");
+});
+
+/*
 app.get("/signin", async (req, res) => {
   const url = new URL(req.url, `http://${req.headers.host}`);
   const errors = url.searchParams.getAll("error");
@@ -120,6 +128,7 @@ app.get("/forgot-password", (req, res) => {
   `)
   );
 });
+*/
 
 app.get("/", requireAuth, async (req: AuthRequest, res) => {
   res.redirect("/dashboard");

--- a/express-auth/index.ts
+++ b/express-auth/index.ts
@@ -12,7 +12,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(auth.createSessionMiddleware());
 
-app.use("/auth", configuredEmailPasswordRouter);
+app.use(configuredEmailPasswordRouter);
 
 const pageTemplate = (body: string) => `
 <html>

--- a/express-auth/package-lock.json
+++ b/express-auth/package-lock.json
@@ -1,0 +1,1284 @@
+{
+  "name": "express-auth",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "express-auth",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "cookie-parser": "^1.4.6",
+        "edgedb": "^1.4.1",
+        "express": "^4.18.2"
+      },
+      "devDependencies": {
+        "@types/cookie-parser": "^1.4.6",
+        "@types/express": "^4.17.21",
+        "@types/node": "^20.10.3",
+        "tsx": "^4.6.2",
+        "typescript": "^5.3.2"
+      }
+    },
+    "../../edgedb-js/packages/auth-express": {
+      "name": "@edgedb/auth-express",
+      "version": "0.1.0-beta.1",
+      "extraneous": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@edgedb/auth-core": "0.1.0-beta.1"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.21",
+        "@types/node": "^20.8.4",
+        "edgedb": "^1.3.6",
+        "express": "^4.18.2",
+        "typescript": "^5.2.2"
+      },
+      "peerDependencies": {
+        "edgedb": "^1.3.6"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-KoooCrD56qlLskXPLGUiJxOMnv5l/8m7cQD2OxJ73NPMhuSz9PmvwRD6EpjDyKBVrdJDdQ4bQK7JFNHnNmax0w==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+      "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.41",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.41.tgz",
+      "integrity": "sha512-OaJ7XLaelTgrvlZD8/aa0vvvxZdUmlCn6MtWeB7TkiKW70BQLc9XEPpDLPdbo52ZhXUCrznlWdCHWxJWtdyajA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "20.10.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.3.tgz",
+      "integrity": "sha512-XJavIpZqiXID5Yxnxv3RUDKTN5b81ddNC3ecsA0SoFXz/QU8OGBwZGMomiq0zw+uuqbL/krztv/DINAQ/EV4gg==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.10",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.10.tgz",
+      "integrity": "sha512-3Gnx08Ns1sEoCrWssEgTSJs/rsT2vhGP+Ja9cnnk9k4ALxinORlQneLXFeFKOTJMOeZUFD1s7w+w2AphTpvzZw==",
+      "dev": true
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.5.tgz",
+      "integrity": "sha512-PDRk21MnK70hja/YF8AHfC7yIsiQHn1rcXx7ijCFBX/k+XQJhQT/gw3xekXKJvx+5SXaMMS8oqQy09Mzvz2TuQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.11.0",
+        "raw-body": "2.5.1",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+      "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.1",
+        "set-function-length": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.5.0.tgz",
+      "integrity": "sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.1",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/edgedb": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/edgedb/-/edgedb-1.4.1.tgz",
+      "integrity": "sha512-GMLeDcTR3lSzpIQCLM6DpcHrVre+nAICA091c0Jfpkd/RANaV7+RSEnIBceDg2rHQpYdCEGW3swULaoURsAQzg==",
+      "bin": {
+        "edgeql-js": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
+    },
+    "node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.1",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.5.0",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.2.0",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.11.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.18.0",
+        "serve-static": "1.15.0",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
+      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+      "dependencies": {
+        "function-bind": "^1.1.2",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "hasown": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
+      "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
+      "dev": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "dependencies": {
+        "get-intrinsic": "^1.2.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.1.tgz",
+      "integrity": "sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/send": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
+      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "dependencies": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.18.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+      "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "dependencies": {
+        "define-data-property": "^1.1.1",
+        "get-intrinsic": "^1.2.1",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
+    },
+    "node_modules/side-channel": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dependencies": {
+        "call-bind": "^1.0.0",
+        "get-intrinsic": "^1.0.2",
+        "object-inspect": "^1.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.6.2.tgz",
+      "integrity": "sha512-QPpBdJo+ZDtqZgAnq86iY/PD2KYCUPSUGIunHdGwyII99GKH+f3z3FZ8XNFLSGQIA4I365ui8wnQpl8OKLqcsg==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "~0.18.20",
+        "get-tsconfig": "^4.7.2"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    }
+  }
+}

--- a/express-auth/package-lock.json
+++ b/express-auth/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@edgedb/auth-express": "^0.1.0-beta.1",
         "cookie-parser": "^1.4.6",
         "edgedb": "^1.4.1",
         "express": "^4.18.2"
@@ -38,6 +39,30 @@
       },
       "peerDependencies": {
         "edgedb": "^1.3.6"
+      }
+    },
+    "node_modules/@edgedb/auth-core": {
+      "version": "0.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@edgedb/auth-core/-/auth-core-0.1.0-beta.1.tgz",
+      "integrity": "sha512-PaX8jplsL2654ahF8IC4GSMLVvEUfgXlYowubW+CEkUaOatWpa03tB2ehU687jUO9fmJrkPThopRQlq0+/Xppg==",
+      "dependencies": {
+        "jwt-decode": "^3.1.2"
+      },
+      "peerDependencies": {
+        "edgedb": "^1.3.6"
+      }
+    },
+    "node_modules/@edgedb/auth-express": {
+      "version": "0.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@edgedb/auth-express/-/auth-express-0.1.0-beta.1.tgz",
+      "integrity": "sha512-j7+H2slaR0SdejJ+zU0mfVOgOC30AS2M8yM1eCYjOWUOu+fHIdi4bLDBjSiiKcAbyTiehTH2kh20GNs/vqJNgw==",
+      "dependencies": {
+        "@edgedb/auth-core": "0.1.0-beta.1"
+      },
+      "peerDependencies": {
+        "cookie-parser": "^1.4.6",
+        "edgedb": "^1.3.6",
+        "express": "^4.18.2"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -938,6 +963,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
     "node_modules/media-typer": {
       "version": "0.3.0",

--- a/express-auth/package-lock.json
+++ b/express-auth/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@edgedb/auth-express": "^0.1.0-beta.1",
+        "@edgedb/auth-express": "^0.1.0-canary.20231219T151133",
         "cookie-parser": "^1.4.6",
         "edgedb": "^1.4.1",
         "express": "^4.18.2"
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@edgedb/auth-express": {
-      "version": "0.1.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@edgedb/auth-express/-/auth-express-0.1.0-beta.1.tgz",
-      "integrity": "sha512-j7+H2slaR0SdejJ+zU0mfVOgOC30AS2M8yM1eCYjOWUOu+fHIdi4bLDBjSiiKcAbyTiehTH2kh20GNs/vqJNgw==",
+      "version": "0.1.0-canary.20231219T151133",
+      "resolved": "https://registry.npmjs.org/@edgedb/auth-express/-/auth-express-0.1.0-canary.20231219T151133.tgz",
+      "integrity": "sha512-BgfoobRpqRD4EU+4ZYKy5cPeHkUI0Q0cUIoeMFP5FGvh9/+4LJFv7uIIaY2XG205ibjqESjTRiis6Y0f9Jkx/Q==",
       "dependencies": {
         "@edgedb/auth-core": "0.1.0-beta.1"
       },

--- a/express-auth/package.json
+++ b/express-auth/package.json
@@ -5,13 +5,14 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "DEBUG=* EDGEDB_CLIENT_SECURITY=insecure_dev_mode tsx watch --clear-screen=false index.ts"
+    "builtin": "DEBUG=* EDGEDB_CLIENT_SECURITY=insecure_dev_mode tsx watch --clear-screen=false builtin.ts",
+    "custom": "DEBUG=* EDGEDB_CLIENT_SECURITY=insecure_dev_mode tsx watch --clear-screen=false custom.ts"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@edgedb/auth-express": "^0.1.0-beta.1",
+    "@edgedb/auth-express": "^0.1.0-canary.20231219T151133",
     "cookie-parser": "^1.4.6",
     "edgedb": "^1.4.1",
     "express": "^4.18.2"

--- a/express-auth/package.json
+++ b/express-auth/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "express-auth",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "cookie-parser": "^1.4.6",
+    "edgedb": "^1.4.1",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/cookie-parser": "^1.4.6",
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.10.3",
+    "tsx": "^4.6.2",
+    "typescript": "^5.3.2"
+  }
+}

--- a/express-auth/package.json
+++ b/express-auth/package.json
@@ -1,6 +1,7 @@
 {
   "name": "express-auth",
   "version": "1.0.0",
+  "type": "module",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/express-auth/package.json
+++ b/express-auth/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "dev": "DEBUG=* EDGEDB_CLIENT_SECURITY=insecure_dev_mode tsx watch --clear-screen=false index.ts"
   },
   "keywords": [],
   "author": "",

--- a/express-auth/package.json
+++ b/express-auth/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@edgedb/auth-express": "^0.1.0-beta.1",
     "cookie-parser": "^1.4.6",
     "edgedb": "^1.4.1",
     "express": "^4.18.2"

--- a/express-auth/styles.ts
+++ b/express-auth/styles.ts
@@ -1,0 +1,68 @@
+export const styles = `
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+main {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+h1 {
+  color: #333;
+}
+
+a {
+  color: #0066cc;
+}
+
+.errors {
+  margin-bottom: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.errors:empty {
+  display: none;
+}
+
+p.error {
+  display: block;
+  padding: 10px;
+  background-color: #ffcccc;
+  color: #cc0000;
+}
+
+.form-control {
+  margin-bottom: 10px;
+  width: 100%;
+}
+
+label {
+  display: block;
+  margin-bottom: 5px;
+}
+
+input {
+  width: 100%;
+  padding: 10px;
+  margin-bottom: 10px;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+button[type="submit"] {
+  padding: 10px 20px;
+  background-color: #0066cc;
+  color: #fff;
+  border: none;
+}
+`;

--- a/express-auth/todos.ts
+++ b/express-auth/todos.ts
@@ -1,0 +1,71 @@
+import express from "express";
+import { AuthRequest } from "@edgedb/auth-express";
+
+import { requireAuth } from "./auth";
+
+export const router = express.Router();
+
+router.get("/", requireAuth, async (req: AuthRequest, res) => {
+  const todos = await req.session!.client.query(`
+    select Todo { * }
+  `);
+  res.json(todos);
+});
+
+router.get("/:id", requireAuth, async (req: AuthRequest, res) => {
+  const { id } = req.params;
+  const todo = await req.session!.client.querySingle(
+    `
+    select Todo { * }
+    filter .id = <uuid>$id
+  `,
+    { id }
+  );
+  res.json(todo);
+});
+
+router.post("/", requireAuth, async (req: AuthRequest, res) => {
+  const { content } = req.body;
+  const todo = await req.session!.client.querySingle(
+    `
+    insert Todo {
+      content := <str>$content
+    }
+  `,
+    { content }
+  );
+  res.json(todo);
+});
+
+router.put("/:id", requireAuth, async (req: AuthRequest, res) => {
+  const { id } = req.params;
+  const { content, completed } = req.body;
+  const todo = await req.session!.client.querySingle(
+    `
+    update Todo
+    filter .id = <uuid>$id
+    set {
+      content := <str>$content,
+      completed := <bool>$completed
+    }
+  `,
+    {
+      id,
+      content,
+      completed,
+    }
+  );
+  res.json(todo);
+});
+
+router.delete("/:id", requireAuth, async (req: AuthRequest, res) => {
+  const { id } = req.params;
+  await req.session!.client.querySingle(
+    `
+    delete Todo
+    filter .id = $id
+  `,
+    { id }
+  );
+  res.sendStatus(204);
+});

--- a/express-auth/todos.ts
+++ b/express-auth/todos.ts
@@ -1,7 +1,7 @@
 import express from "express";
 import { AuthRequest } from "@edgedb/auth-express";
 
-import { requireAuth } from "./auth";
+import { requireAuth } from "./auth.js";
 
 export const router = express.Router();
 

--- a/express-auth/tsconfig.json
+++ b/express-auth/tsconfig.json
@@ -25,11 +25,11 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs" /* Specify what module code is generated. */,
+    "module": "Node16" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
-    "paths": {} /* Specify a set of entries that re-map imports to additional lookup locations. */,
+    //"paths": {} /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
@@ -76,7 +76,7 @@
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
-    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    //"allowSyntheticDefaultImports": false,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
     "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,

--- a/express-auth/tsconfig.json
+++ b/express-auth/tsconfig.json
@@ -1,0 +1,112 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "commonjs" /* Specify what module code is generated. */,
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
+    "paths": {
+      "@edgedb/auth-express": ["node_modules/@edgedb/auth-express/src"],
+      "@edgedb/auth-express/*": ["node_modules/@edgedb/auth-express/src/*"]
+    } /* Specify a set of entries that re-map imports to additional lookup locations. */,
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+    /* Type Checking */
+    "strict": true /* Enable all strict type-checking options. */,
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+  }
+}

--- a/express-auth/tsconfig.json
+++ b/express-auth/tsconfig.json
@@ -29,10 +29,7 @@
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
-    "paths": {
-      "@edgedb/auth-express": ["node_modules/@edgedb/auth-express/src"],
-      "@edgedb/auth-express/*": ["node_modules/@edgedb/auth-express/src/*"]
-    } /* Specify a set of entries that re-map imports to additional lookup locations. */,
+    "paths": {} /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
     // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */


### PR DESCRIPTION
Very barebones example app:

- adds the required auth-related routes with idiomatic Express route handling
  - Show success handling with route handlers
  - Show error handling with route-specific error handlers
- shows how to create middleware for protecting routes
- shows using the session middleware to add an authenticated client

Blocked on publishing the express auth helper package, but tested locally via `npm link`.