### PR TITLE
Bump EdgeDB version in fastapi-crud example project

### DIFF
--- a/fastapi-crud/edgedb.toml
+++ b/fastapi-crud/edgedb.toml
@@ -1,2 +1,2 @@
 [edgedb]
-server-version = "2.9"
+server-version = "4.4"


### PR DESCRIPTION
Manually tested with edgedb-python 1.8.0 (with the Pydantic v2 fix), @raddevon please also drop the Pydantic warning at the top of [our docs page for FastAPI](https://www.edgedb.com/docs/guides/tutorials/rest_apis_with_fastapi#fastapi) 🙏 