### PR TITLE
fixed issue with redirect link. Now directing to the correct repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repo contains starter projects that demonstrate usage of EdgeDB with differ
 | --------------------------- | -------------------------------------------------------------------------------------------- |
 | Deno Fresh                  | [deno-fresh](https://github.com/edgedb/edgedb-examples/tree/main/deno-fresh)                 |
 | Nest.js                     | [nestjs-crud](https://github.com/edgedb/edgedb-examples/tree/main/nestjs-crud)               |
-| Next.js Blog (App Router)   | [nextjs-app-router](https://github.com/edgedb/edgedb-examples/tree/main/nextjs-app-router)   |
+| Next.js Blog (App Router)   | [nextjs-app-router](https://github.com/edgedb/edgedb-examples/tree/main/nextjs-blog-app-router)   |
 | Next.js Blog (Pages Router) | [nextjs-blog](https://github.com/edgedb/edgedb-examples/tree/main/nextjs-blog)               |
 | Next.js Todo                | [nextjs-todo](https://github.com/edgedb/edgedb-examples/tree/main/nextjs-todo)               |
 | Remix                       | [remix](https://github.com/edgedb/edgedb-examples/tree/main/remix)                           |


### PR DESCRIPTION
Issue: Redirecting to an non-existing repo.
Before: 
![image](https://github.com/edgedb/edgedb-examples/assets/113078518/2653278f-0c0b-4890-b5c5-844bb3eb0795)

After: 
![image](https://github.com/edgedb/edgedb-examples/assets/113078518/029439c1-47f4-4455-818d-52825398cab6)

Change: https://github.com/edgedb/edgedb-examples/tree/main/nextjs-app-router ---> https://github.com/edgedb/edgedb-examples/tree/main/nextjs-blog-app-router